### PR TITLE
Missing view ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *~
 *.class
 .DS_Store
+*.iml
+*.ipr
+*.iws

--- a/src/main/resources/lif-all.json
+++ b/src/main/resources/lif-all.json
@@ -9,6 +9,7 @@
     },
     "views": [
       {
+        "id": "v1",
         "metadata": {
           "contains": {
             "http://vocab.lappsgrid.org/Sentence": {


### PR DESCRIPTION
Add `id` property to the `view`.

The missing ID field causes the file to fail schema validation.